### PR TITLE
Added ontluchting and afsluiter appurtenances

### DIFF
--- a/5. visualisatie/symbology/iconen/svg/ontluchting_BGI.svg
+++ b/5. visualisatie/symbology/iconen/svg/ontluchting_BGI.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="20"
+   width="10"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="ontluchting_BGI.svg">
+  <metadata
+     id="metadata11">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs9" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="692"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="11.8"
+     inkscape:cx="-9.9152542"
+     inkscape:cy="10"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     style="fill:none;stroke:#ff7f00;stroke-width:1.95897937000000000;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     d="m 0.979326,4.979204 4.07955,-4 4.07955,4"
+     id="path3085"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="fill:none;stroke:#ff7f00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     d="m 5.059326,1.060204 0,8.09"
+     id="path3087" />
+</svg>

--- a/5. visualisatie/symbology/sld-themasappurtenance.xml
+++ b/5. visualisatie/symbology/sld-themasappurtenance.xml
@@ -7,6 +7,7 @@
         <UserStyle>
             <Title>Thema's</Title>
             <Abstract>Deze stylesheet bevat de regels voor de visualisatie van alle appurtenances obv thema</Abstract>
+            <!--
             <FeatureTypeStyle>
                 <Rule>
                     <Name>appurtenances</Name>
@@ -26,15 +27,92 @@
                     </PointSymbolizer>
                 </Rule>
             </FeatureTypeStyle>
+            -->
             <FeatureTypeStyle>
                 <Rule>
                     <Name>buisleidinggevaarlijkeinhoud</Name>
                     <Title>Buisleiding Gevaarlijke Inhoud (BGI)</Title>
                     <ogc:Filter>
-                        <ogc:PropertyIsEqualTo>
-                            <ogc:PropertyName>thema</ogc:PropertyName>
-                            <ogc:Literal>BGI</ogc:Literal>
-                        </ogc:PropertyIsEqualTo>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>thema</ogc:PropertyName>
+                                <ogc:Literal>BGI</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>appurtenanceType</ogc:PropertyName>
+                                <ogc:Literal>afsluiter</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+                            <Mark>
+                                <WellKnownName>shape://vertline</WellKnownName>
+                                 <Stroke>
+                                    <CssParameter name="stroke">#ff7f00</CssParameter>
+                                    <CssParameter name="stroke-width">2</CssParameter>
+                                </Stroke>
+                            </Mark>
+                            <Size>10</Size>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
+                <Rule>
+                    <Name>buisleidinggevaarlijkeinhoud</Name>
+                    <Title>Buisleiding Gevaarlijke Inhoud (BGI)</Title>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>thema</ogc:PropertyName>
+                                <ogc:Literal>BGI</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>appurtenanceType</ogc:PropertyName>
+                                <ogc:Literal>ontluchting</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                        </ogc:And>
+                    </ogc:Filter>
+                    <MinScaleDenominator>0</MinScaleDenominator>
+                    <MaxScaleDenominator>5000</MaxScaleDenominator>
+                    <PointSymbolizer>
+                        <Graphic>
+							<ExternalGraphic>
+								<OnlineResource xlink:type="simple" xlink:href="ontluchting_BGI.svg"/>
+								<Format>image/svg+xml</Format>
+							</ExternalGraphic>
+                        </Graphic>
+                    </PointSymbolizer>
+                </Rule>
+                <Rule>
+                    <Name>buisleidinggevaarlijkeinhoud</Name>
+                    <Title>Buisleiding Gevaarlijke Inhoud (BGI)</Title>
+                    <ogc:Filter>
+                        <ogc:And>
+                            <ogc:PropertyIsEqualTo>
+                                <ogc:PropertyName>thema</ogc:PropertyName>
+                                <ogc:Literal>BGI</ogc:Literal>
+                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>appurtenanceType</ogc:PropertyName>
+                                    <ogc:Literal>Tstuk</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>appurtenanceType</ogc:PropertyName>
+                                    <ogc:Literal>Gasstation</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>appurtenanceType</ogc:PropertyName>
+                                    <ogc:Literal>algemeen (gas) transport onderdeel</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>appurtenanceType</ogc:PropertyName>
+                                    <ogc:Literal>bocht</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                            </ogc:Or>
+                        </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
                     <MaxScaleDenominator>5000</MaxScaleDenominator>


### PR DESCRIPTION
To extend the visualisation of appurtenances, I have created a new SVG icon for "ontluchting" and added SLD rules to filter the appurtenanceType attribute.