### PR TITLE
Generate closed arrow per documentation.

### DIFF
--- a/IMKL2.x/5-visualisatie/symbology/sld-annotatie-lijn.xml
+++ b/IMKL2.x/5-visualisatie/symbology/sld-annotatie-lijn.xml
@@ -52,7 +52,7 @@
                         </Geometry>
                         <Graphic>
                             <Mark>
-                                <WellKnownName>shape://oarrow</WellKnownName>
+                                <WellKnownName>shape://carrow</WellKnownName>
                                 <Fill>
                                     <CssParameter name="fill">#000000</CssParameter>
                                 </Fill>


### PR DESCRIPTION
Addresses issue (#335) and changes the open arrow to a closed arrow to align with the style as described in the documentation.