### PR TITLE
Visualise extrageometrie of objects that don't have a currentStatus attribute value (#267)

### DIFF
--- a/IMKL2.x/5-visualisatie/symbology/sld-ductkabelbedmetextrageometrie.xml
+++ b/IMKL2.x/5-visualisatie/symbology/sld-ductkabelbedmetextrageometrie.xml
@@ -104,10 +104,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -131,10 +136,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -158,10 +168,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -353,10 +368,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -380,10 +400,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -407,10 +432,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -602,10 +632,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -629,10 +664,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -656,10 +696,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -851,10 +896,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -878,10 +928,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -905,10 +960,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -1100,10 +1160,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -1127,10 +1192,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -1154,10 +1224,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -1349,10 +1424,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -1376,10 +1456,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -1403,10 +1488,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -1598,10 +1688,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -1625,10 +1720,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -1652,10 +1752,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -1847,10 +1952,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -1874,10 +1984,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -1901,10 +2016,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -2096,10 +2216,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -2123,10 +2248,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -2150,10 +2280,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -2345,10 +2480,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -2372,10 +2512,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -2399,10 +2544,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -2594,10 +2744,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -2621,10 +2776,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -2648,10 +2808,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -2843,10 +3008,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -2870,10 +3040,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -2897,10 +3072,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -3092,10 +3272,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -3119,10 +3304,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -3146,10 +3336,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -3341,10 +3536,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -3368,10 +3568,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -3395,10 +3600,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -3590,10 +3800,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -3617,10 +3832,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -3644,10 +3864,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>

--- a/IMKL2.x/5-visualisatie/symbology/sld-kabelleidingmetextrageometrie.xml
+++ b/IMKL2.x/5-visualisatie/symbology/sld-kabelleidingmetextrageometrie.xml
@@ -101,10 +101,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -128,10 +133,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -155,10 +165,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -350,10 +365,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -377,10 +397,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -404,10 +429,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -599,10 +629,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -626,10 +661,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -653,10 +693,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -848,10 +893,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -875,10 +925,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -902,10 +957,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -1097,10 +1157,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -1124,10 +1189,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -1151,10 +1221,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -1346,10 +1421,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -1373,10 +1453,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -1400,10 +1485,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -1595,10 +1685,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -1622,10 +1717,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -1649,10 +1749,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -1844,10 +1949,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -1871,10 +1981,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -1898,10 +2013,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -2093,10 +2213,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -2120,10 +2245,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -2147,10 +2277,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -2342,10 +2477,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -2369,10 +2509,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -2396,10 +2541,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -2591,10 +2741,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -2618,10 +2773,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -2645,10 +2805,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -2840,10 +3005,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -2867,10 +3037,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -2894,10 +3069,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -3089,10 +3269,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -3116,10 +3301,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -3143,10 +3333,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -3338,10 +3533,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -3365,10 +3565,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -3392,10 +3597,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>
@@ -3587,10 +3797,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -3614,10 +3829,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>501</MinScaleDenominator>
@@ -3641,10 +3861,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>10001</MinScaleDenominator>

--- a/IMKL2.x/5-visualisatie/symbology/sld-kastmetextrageometrie.xml
+++ b/IMKL2.x/5-visualisatie/symbology/sld-kastmetextrageometrie.xml
@@ -44,10 +44,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -115,10 +120,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -186,10 +196,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -257,10 +272,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -328,10 +348,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -399,10 +424,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -470,10 +500,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -541,10 +576,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -612,10 +652,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -683,10 +728,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -754,10 +804,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -825,10 +880,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -896,10 +956,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -967,10 +1032,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -1038,10 +1108,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>

--- a/IMKL2.x/5-visualisatie/symbology/sld-leidingelementmetextrageometrie.xml
+++ b/IMKL2.x/5-visualisatie/symbology/sld-leidingelementmetextrageometrie.xml
@@ -45,10 +45,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -119,10 +124,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -193,10 +203,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -267,10 +282,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -341,10 +361,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -415,10 +440,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -489,10 +519,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -563,10 +598,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -637,10 +677,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -711,10 +756,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -785,10 +835,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -859,10 +914,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -933,10 +993,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -1007,10 +1072,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -1081,10 +1151,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>

--- a/IMKL2.x/5-visualisatie/symbology/sld-mangatmetextrageometrie.xml
+++ b/IMKL2.x/5-visualisatie/symbology/sld-mangatmetextrageometrie.xml
@@ -44,10 +44,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -115,10 +120,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -186,10 +196,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -257,10 +272,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -328,10 +348,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -399,10 +424,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -470,10 +500,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -541,10 +576,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -612,10 +652,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -683,10 +728,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -754,10 +804,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -825,10 +880,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -896,10 +956,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -967,10 +1032,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -1038,10 +1108,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>

--- a/IMKL2.x/5-visualisatie/symbology/sld-mantelbuismetextrageometrie.xml
+++ b/IMKL2.x/5-visualisatie/symbology/sld-mantelbuismetextrageometrie.xml
@@ -45,10 +45,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -119,10 +124,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -193,10 +203,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -267,10 +282,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -341,10 +361,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -415,10 +440,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -489,10 +519,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -563,10 +598,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -637,10 +677,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -711,10 +756,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -785,10 +835,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -859,10 +914,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -933,10 +993,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -1007,10 +1072,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>
@@ -1081,10 +1151,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MinScaleDenominator>0</MinScaleDenominator>

--- a/IMKL2.x/5-visualisatie/symbology/sld-mastmetextrageometrie.xml
+++ b/IMKL2.x/5-visualisatie/symbology/sld-mastmetextrageometrie.xml
@@ -44,10 +44,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -115,10 +120,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -186,10 +196,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -257,10 +272,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -328,10 +348,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -399,10 +424,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -470,10 +500,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -541,10 +576,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -612,10 +652,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -683,10 +728,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -754,10 +804,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -825,10 +880,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -896,10 +956,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -967,10 +1032,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -1038,10 +1108,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>

--- a/IMKL2.x/5-visualisatie/symbology/sld-technischgebouwmetextrageometrie.xml
+++ b/IMKL2.x/5-visualisatie/symbology/sld-technischgebouwmetextrageometrie.xml
@@ -44,10 +44,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -115,10 +120,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -186,10 +196,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -257,10 +272,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -328,10 +348,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -399,10 +424,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -470,10 +500,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -541,10 +576,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -612,10 +652,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -683,10 +728,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -754,10 +804,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -825,10 +880,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -896,10 +956,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -967,10 +1032,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -1038,10 +1108,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>

--- a/IMKL2.x/5-visualisatie/symbology/sld-torenmetextrageometrie.xml
+++ b/IMKL2.x/5-visualisatie/symbology/sld-torenmetextrageometrie.xml
@@ -44,10 +44,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>buisleidingGevaarlijkeInhoud</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -115,10 +120,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>datatransport</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -186,10 +196,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasHogeDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -257,10 +272,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>gasLageDruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -328,10 +348,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>petrochemie</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -399,10 +424,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>laagspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -470,10 +500,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>middenspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -541,10 +576,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>hoogspanning</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -612,10 +652,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>landelijkHoogspanningsnet</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -683,10 +728,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>water</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -754,10 +804,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>warmte</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -825,10 +880,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolOnderOverOfOnderdruk</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -896,10 +956,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>rioolVrijverval</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -967,10 +1032,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>wees</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>
@@ -1038,10 +1108,15 @@
                                 <ogc:PropertyName>thema</ogc:PropertyName>
                                 <ogc:Literal>overig</ogc:Literal>
                             </ogc:PropertyIsEqualTo>
-                            <ogc:PropertyIsEqualTo>
-                                <ogc:PropertyName>currentStatus</ogc:PropertyName>
-                                <ogc:Literal>functional</ogc:Literal>
-                            </ogc:PropertyIsEqualTo>
+                            <ogc:Or>
+                                <ogc:PropertyIsEqualTo>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                    <ogc:Literal>functional</ogc:Literal>
+                                </ogc:PropertyIsEqualTo>
+                                <ogc:PropertyIsNull>
+                                    <ogc:PropertyName>currentStatus</ogc:PropertyName>
+                                </ogc:PropertyIsNull>
+                            </ogc:Or>
                         </ogc:And>
                     </ogc:Filter>
                     <MaxScaleDenominator>10000</MaxScaleDenominator>


### PR DESCRIPTION
In case the parent object of extrageometrie is outside the area of interest, the currentStatus attribute value is not known. In that case, the visualisation presents this child object as if the currentStatus is 'functional'.